### PR TITLE
add: useWindowSize hook for handling window resize events

### DIFF
--- a/src/hooks/useDesktopMode.ts
+++ b/src/hooks/useDesktopMode.ts
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'react';
 type DesktopMode = 'light' | 'dark';
 
 export const useDesktopMode = (): {
-    desktopMode: string;
+    desktopMode: DesktopMode;
     toggleDesktopMode: () => void;
 } => {
     const [desktopMode, setDesktopMode] = useState<DesktopMode>('light');

--- a/src/hooks/useWindowsize.ts
+++ b/src/hooks/useWindowsize.ts
@@ -1,0 +1,23 @@
+import { useEffect, useState } from 'react';
+
+export const useWindowSize = (): { width: number; height: number } => {
+    const [windowSize, setWindowSize] = useState({ width: window.innerWidth, height: window.innerHeight });
+
+    useEffect(() => {
+        const handleWindowResize = (): void => {
+            setWindowSize({
+                width: window.innerWidth,
+                height: window.innerHeight,
+            });
+        };
+
+        // resize event: only occurs on the window object and fires continuously when the browser window is resized
+        window.addEventListener('resize', handleWindowResize);
+
+        return (): void => {
+            window.removeEventListener('resize', handleWindowResize);
+        };
+    }, []);
+
+    return windowSize;
+};


### PR DESCRIPTION
- add useWindowSize hook for handling window resize events
- window의 크기에 따라 달라지는 UI를 구현하기 위해 만든 훅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new custom hook, `useWindowSize`, to manage and provide the current dimensions of the window.
- **Improvements**
	- Enhanced type safety for the `useDesktopMode` hook by specifying the return type for `desktopMode` as either 'light' or 'dark'.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->